### PR TITLE
Fix the name of parameter `vsphere_cert_check` to match the code

### DIFF
--- a/vsphere-inventory.ini
+++ b/vsphere-inventory.ini
@@ -2,7 +2,7 @@
 cache_path = /tmp/ansible-vsphere-inventory-cache.tmp
 cache_ttl = 7200
 vsphere_port = 443
-vsphere_check_cert = False
+vsphere_cert_check = False
 vsphere_user = VSPHERE_READ_ONLY_USER
 vsphere_pass = VSPHERE_READ_ONLY_USER_PASSWORD
 vsphere_host = VSPHERE_FQDN


### PR DESCRIPTION
There was a mismatch between the parameter sourced in the code (`vsphere_cert_check`) and the configuration file (`vsphere_check_cert`).